### PR TITLE
remove unstable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,6 @@
 //! assert_eq!(stmt.to_sql(), "EXECUTE idplan('foo');");
 //! ```
 
-#![feature(min_type_alias_impl_trait)]
-
 #[cfg(feature = "sqlx")]
 pub mod fetch;
 #[cfg(feature = "sqlx")]


### PR DESCRIPTION
If you do need this in future I'd recommend introducing a `nightly` feature flag on the crate.

Either way, since the feature is mainly useful for reducing number of breaking changes it is of less concern for a new evolving lib like this.

closes #3