### PR TITLE
Optimize table macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,31 @@ members = [
 name = "typed_sql"
 
 [features]
-default = ["sqlx"]
+
+default = ["all-types", "sqlx"]
+
+# type
+all-types = [ "chrono", "time", "bigdecimal", "decimal", "ipnetwork", "json", "uuid", "bit-vec" ]
+bigdecimal = [ "bigdecimal_", "num-bigint" ]
+decimal = [ "rust_decimal", "num-bigint" ]
+json = [ "serde", "serde_json" ]
+
 
 [dependencies]
 async-trait = "0.1.50"
 typed-sql-derive = { path = "typed-sql-derive" }
 
-[dependencies.sqlx]
-version = "0.5.5"
-optional = true
-features = ["runtime-tokio-native-tls"]
+bigdecimal_ = { version = "0.2.0", optional = true, package = "bigdecimal" }
+rust_decimal = { version = "1.7.0", optional = true }
+bit-vec = { version = "0.6.2", optional = true }
+chrono = { version = "0.4.11", default-features = false, features = [ "clock" ], optional = true }
+ipnetwork = { version = "0.18.0", default-features = false, optional = true }
+num-bigint = { version = "0.4.0", default-features = false, optional = true, features = [ "std" ] }
+serde = { version = "1.0.106", features = [ "derive", "rc" ], optional = true }
+serde_json = { version = "1.0.51", features = [ "raw_value" ], optional = true }
+time = { version = "0.2.16", optional = true }
+uuid = { version = "0.8.1", default-features = false, optional = true, features = [ "std" ] }
+
+sqlx = { version = "0.5.5", optional = true }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ name = "typed_sql"
 default = ["all-types", "sqlx"]
 
 # type
-all-types = [ "chrono", "time", "bigdecimal", "decimal", "ipnetwork", "json", "uuid", "bit-vec" ]
+all-types = [ "chrono", "time", "bigdecimal", "decimal", "ipnetwork", "json", "uuid", "bitvec" ]
 bigdecimal = [ "bigdecimal_", "num-bigint" ]
 decimal = [ "rust_decimal", "num-bigint" ]
 json = [ "serde", "serde_json" ]
-
+bitvec = [ "serde", "serde_json", "bit-vec" ]
 
 [dependencies]
 async-trait = "0.1.50"
@@ -33,7 +33,7 @@ typed-sql-derive = { path = "typed-sql-derive" }
 
 bigdecimal_ = { version = "0.2.0", optional = true, package = "bigdecimal" }
 rust_decimal = { version = "1.7.0", optional = true }
-bit-vec = { version = "0.6.2", optional = true }
+bit-vec = { version = "0.6.2", optional = true, features=["serde"] }
 chrono = { version = "0.4.11", default-features = false, features = [ "clock" ], optional = true }
 ipnetwork = { version = "0.18.0", default-features = false, optional = true }
 num-bigint = { version = "0.4.0", default-features = false, optional = true, features = [ "std" ] }
@@ -42,6 +42,6 @@ serde_json = { version = "1.0.51", features = [ "raw_value" ], optional = true }
 time = { version = "0.2.16", optional = true }
 uuid = { version = "0.8.1", default-features = false, optional = true, features = [ "std" ] }
 
-sqlx = { version = "0.5.5", optional = true }
+sqlx = { version = "0.5.5", optional = true, features=["runtime-async-std-native-tls"] }
 
 

--- a/src/types/bigdecimal.rs
+++ b/src/types/bigdecimal.rs
@@ -1,0 +1,10 @@
+use super::Primitive;
+use bigdecimal_::BigDecimal;
+
+impl Primitive for BigDecimal {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/bitvec.rs
+++ b/src/types/bitvec.rs
@@ -1,0 +1,13 @@
+use super::Primitive;
+use bit_vec::BitVec;
+use serde::{Deserialize, Serialize};
+
+impl Primitive for BitVec {
+    fn write_primative(&self, sql: &mut String) {
+        let btcvec = serde_json::to_string(self).unwrap();
+
+        sql.push('\'');
+        sql.push_str(&btcvec);
+        sql.push('\'');
+    }
+}

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -1,0 +1,42 @@
+use super::Primitive;
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+impl Primitive for DateTime<Utc> {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for DateTime<Local> {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for NaiveDateTime {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for NaiveDate {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for NaiveTime {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -1,0 +1,10 @@
+use super::Primitive;
+use rust_decimal::Decimal;
+
+impl Primitive for Decimal {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/ipnetwork.rs
+++ b/src/types/ipnetwork.rs
@@ -1,0 +1,10 @@
+use super::Primitive;
+use ipnetwork::IpNetwork;
+
+impl Primitive for IpNetwork {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -1,0 +1,10 @@
+use super::Primitive;
+use serde_json::Value;
+
+impl Primitive for Value {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,6 +6,8 @@ pub use bind::{Bind, Binding};
 pub mod field;
 pub use field::Field;
 
+#[cfg(feature = "chrono")]
+mod chrono;
 pub trait Primitive {
     fn write_primative(&self, sql: &mut String);
 }
@@ -39,5 +41,11 @@ impl<P: Primitive> Primitive for Option<P> {
         } else {
             sql.push_str("NULL");
         }
+    }
+}
+
+impl Primitive for bool {
+    fn write_primative(&self, sql: &mut String) {
+        sql.write_fmt(format_args!("{}", self)).unwrap();
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,6 +8,28 @@ pub use field::Field;
 
 #[cfg(feature = "chrono")]
 mod chrono;
+
+#[cfg(feature = "bigdecimal")]
+mod bigdecimal;
+
+#[cfg(feature = "json")]
+mod json;
+
+#[cfg(feature = "time")]
+mod time;
+
+#[cfg(feature = "decimal")]
+mod decimal;
+
+#[cfg(feature = "ipnetwork")]
+mod ipnetwork;
+
+#[cfg(feature = "uuid")]
+mod uuid;
+
+#[cfg(feature = "bitvec")]
+mod bitvec;
+
 pub trait Primitive {
     fn write_primative(&self, sql: &mut String);
 }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,0 +1,33 @@
+use super::Primitive;
+use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+
+impl Primitive for PrimitiveDateTime {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for OffsetDateTime {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+
+impl Primitive for Date {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}
+impl Primitive for Time {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,0 +1,10 @@
+use super::Primitive;
+use uuid::Uuid;
+
+impl Primitive for Uuid {
+    fn write_primative(&self, sql: &mut String) {
+        sql.push('\'');
+        sql.push_str(&self.to_string());
+        sql.push('\'');
+    }
+}

--- a/typed-sql-derive/src/lib.rs
+++ b/typed-sql-derive/src/lib.rs
@@ -36,13 +36,12 @@ pub fn table(input: TokenStream) -> TokenStream {
         });
 
         let table_name = {
-            let mut s = ident.to_string().to_lowercase();
-            s.push('s');
+            let s = ident.to_string().to_lowercase();
             Ident::new(&s, Span::call_site())
         };
 
         let expanded = quote! {
-            struct #fields_ident {
+            pub struct #fields_ident {
               #(#struct_fields)*
             }
 


### PR DESCRIPTION
We don't need to add plural forms to user-defined structs. This will cause unexpected troubles. Making the fields_ident public can better use the Primitive trait.