### PR TITLE
Added a custom table name macro

### DIFF
--- a/typed-sql-derive/src/lib.rs
+++ b/typed-sql-derive/src/lib.rs
@@ -36,13 +36,12 @@ pub fn table(input: TokenStream) -> TokenStream {
         });
 
         let table_name = {
-            let mut s = ident.to_string().to_lowercase();
-            s.push('s');
+            let s = ident.to_string().to_lowercase();
             Ident::new(&s, Span::call_site())
         };
 
         let expanded = quote! {
-            struct #fields_ident {
+            pub struct #fields_ident {
               #(#struct_fields)*
             }
 


### PR DESCRIPTION
#11 
Its usage is like this.
```rust```
  #[derive(Debug, Deserialize, Serialize, Table)]
  #[typed(table_name = "page")]
  pub struct PageItem {
      id: Option<i64>,
      url: String,
      name: String,
      description: String,
      create_time: NaiveDateTime,
      update_time: NaiveDateTime,
  }
page is our new table name。